### PR TITLE
Add autoloading information to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,10 @@
   "require": {
     "typo3/cms-core": "7.*|8.*|9.*",
     "php": "~5.6|~7.0|~7.1|~7.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "SchamsNet\\Nagios\\": "Classes"
+    }
   }
 }


### PR DESCRIPTION
So yesterday i tried installing this extension in "composer mode".
Since it wasn't listed on Packagist, i added the GitHub repo to my composer.json and tried a `composer  require` afterwards. The extension popped up in my extension manager, i could edit the settings but when requesting `/index.php?eID=nagios` i was greeted with a "Class not found" error due to autoloading issues.

Fixed that issue by adding autoload information to the composer.json
I'm not too experienced with Typo3 extension development but i'd suggest publishing this repo on Packagist and Tag versions again so people don't have to `composer require schams-net/nagios:dev-master`