### PR TITLE
Allow hyphen and underscore in URL

### DIFF
--- a/Classes/Middleware/NagiosMiddleware.php
+++ b/Classes/Middleware/NagiosMiddleware.php
@@ -85,7 +85,7 @@ class NagiosMiddleware implements MiddlewareInterface
         $expectedUri = $this->extensionConfiguration->get($this->extensionKey, 'expectedUri');
         $expectedUri = self::sanitizeString($expectedUri);
 
-        if (preg_match('/^\/[a-zA-Z0-9\/]{3,}/', $expectedUri) && $requestUri === $expectedUri) {
+        if (preg_match('/^\/[a-zA-Z0-9\/\-\_]{3,}/', $expectedUri) && $requestUri === $expectedUri) {
             return true;
         }
 


### PR DESCRIPTION
Regular expression for checking the url path should take hyphen and underscore into account.