### PR TITLE
TYPO3 v12 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^11",
+        "typo3/cms-core": "^11 || ^12",
         "php": "^7.4 || ^8.0 || ^8.1 || ^8.2"
     },
     "extra": {


### PR DESCRIPTION
Hi @schams-net ,

I just installed the first test project in TYPO3 v12 and noticed that the nagios extension is not marked compatible yet.

I tried to use it with TYPO3 v12 PHP 8.1 and PHP 8.2 and got the expected answer.

```
# Nagios TYPO3 Monitoring Version master - https://schams.net/nagios

EXT:adminpanel-version-12.4.2
EXT:backend-version-12.4.2
EXT:belog-version-12.4.2
EXT:beuser-version-12.4.2
EXT:core-version-12.4.2
EXT:dashboard-version-12.4.2
EXT:extbase-version-12.4.2
EXT:extensionmanager-version-12.4.2
EXT:filelist-version-12.4.2
EXT:fluid-version-12.4.2
EXT:fluid_styled_content-version-12.4.2
EXT:form-version-12.4.2
EXT:frontend-version-12.4.2
EXT:impexp-version-12.4.2
EXT:info-version-12.4.2
EXT:install-version-12.4.2
EXT:lowlevel-version-12.4.2
EXT:nagios-version-master
EXT:opendocs-version-12.4.2
EXT:recycler-version-12.4.2
EXT:redirects-version-12.4.2
EXT:reports-version-12.4.2
EXT:rte_ckeditor-version-12.4.2
EXT:scheduler-version-12.4.2
EXT:seo-version-12.4.2
EXT:setup-version-12.4.2
EXT:tstemplate-version-12.4.2
EXT:typo3_console-version-8.0.3
EXT:viewpage-version-12.4.2
TYPO3:version-12.4.2
APPLICATIONCONTEXT:development/local
PHP:version-8.2.1
TIMESTAMP:1688035003-CEST
```

Looks good to me so I just adjusted the `composer.json ` constraint.

Maybe you can just publish an new version with this. Otherwise let me know if I can help you.

Regards 
Markus